### PR TITLE
Fix: Python 3.9 pip failure in rhelai_model_serve (PARTNER ONLY - Summit unaffected)

### DIFF
--- a/roles/rhelai_model_serve/tasks/main.yml
+++ b/roles/rhelai_model_serve/tasks/main.yml
@@ -3,15 +3,10 @@
   become: "{{ rhelai_model_serve_become }}"
   become_user: "{{ rhelai_model_serve_become_user }}"
   block:
-    - name: Download pip
-      ansible.builtin.get_url:
-        url: "https://bootstrap.pypa.io/get-pip.py"
-        dest: /root/
-        mode: '0644'
-
-    - name: Install pip
-      ansible.builtin.command:
-        cmd: "python /root/get-pip.py"
+    - name: Install pip via package manager
+      ansible.builtin.package:
+        name: python3-pip
+        state: present
 
     - name: Install ruamel
       ansible.builtin.pip:


### PR DESCRIPTION
## ⚠️ DRAFT PR - AFFECTS PARTNER CATALOG ONLY, DOES NOT TOUCH SUMMIT ⚠️

### 🎯 Impact Scope

**✅ WILL FIX:**
- `partner/ai-driven-ansible-automation` catalog item
- Any other deployments using `version: main` from this collection

**❌ WILL NOT AFFECT:**
- `summit-2026/lb2759-agentic-aiops-aap-cnv` event deployments
- Summit uses **pinned commit** `6b591e46...` and will not receive this change
- Summit deployments are **completely isolated** from this PR

### Why Summit is Unaffected

**Summit version control (event.yaml):**
```yaml
requirements_content:
  collections:
    - name: https://github.com/rhpds/lb2961.ai_driven_aap.git
      type: git
      version: "6b591e46a3b15c81077df69053757230c193a1f5"  # ← PINNED COMMIT
```
- Uses a **specific git commit hash** from April 2026
- Never pulls from `main` or `feat/continue-dev-config` branches
- Will **only** get changes if someone explicitly updates the commit hash
- This PR merging to `main` has **zero impact** on Summit

**Partner version control (common.yaml):**
```yaml
requirements_content:
  collections:
    - name: https://github.com/rhpds/lb2961.ai_driven_aap.git
      type: git
      version: main  # ← TRACKS MAIN BRANCH
```
- Pulls **latest code** from `main` branch on every deployment
- **Will automatically get this fix** when merged

### Affected vs Unaffected Comparison

| Aspect | Partner | Summit 2026 |
|--------|---------|-------------|
| **Deploys rhelai instance?** | ✅ Yes (g6.2xlarge GPU) | ❌ No (uses LiteLLM API) |
| **Invokes rhelai_model_serve?** | ✅ Yes | ❌ No |
| **Collection version** | `main` (dynamic) | `6b591e46...` (pinned) |
| **Gets this PR?** | ✅ Yes (automatic) | ❌ No (isolated) |
| **Current status** | 🔴 FAILING | 🟢 WORKING |
| **After merge** | 🟢 FIXED | 🟢 STILL WORKING |

### Problem (Partner Only)
- **get-pip.py** from `bootstrap.pypa.io` now requires Python 3.10+ (as of May 4, 2026)
- **pip 26.1** dropped Python 3.9 support (Python 3.9 reached EOL on Oct 31, 2025)
- Partner catalog item uses AWS AMI with **Python 3.9**
- Partner deployments failing since May 12, 2026 with error:
  ```
  ERROR: This script does not work on Python 3.9. The minimum supported Python version is 3.10.
  TASK [lb2961.ai_driven_aap.rhelai_model_serve : Install pip] *******************
  fatal: [rhelai.example.com]: FAILED!
  ```

### Summit Verification (Currently Working)
Confirmed working deployment:
https://babylon-catalog.apps.ocp-us-west-2.infra.open.redhat.com/workshops/user-klewis-redhat-com/summit-2026.lb2759-agentic-aiops-aap-cnv.event-rdslq

Summit does **not** use the `rhelai_model_serve` role at all - the role exists in the collection but is never invoked in Summit's workload configuration.

### Solution
Replace the `get-pip.py` download/install approach with system package manager:

**Before:**
```yaml
- name: Download pip
  ansible.builtin.get_url:
    url: "https://bootstrap.pypa.io/get-pip.py"
    dest: /root/
    mode: '0644'

- name: Install pip
  ansible.builtin.command:
    cmd: "python /root/get-pip.py"
```

**After:**
```yaml
- name: Install pip via package manager
  ansible.builtin.package:
    name: python3-pip
    state: present
```

### Why This Approach?
✅ Uses system-provided `python3-pip` package  
✅ More reliable and follows distribution best practices  
✅ Works with Python 3.9 (AWS AMI default)  
✅ Avoids external script dependencies  
✅ Cleaner and more maintainable  

### Testing Required
- [ ] Test on **partner dev environment** with AWS deployment
- [ ] Verify pip installation succeeds on RHELAI13 AMI (Python 3.9)
- [ ] Verify `ruamel.yaml` pip package installs successfully
- [ ] Verify ilab model serve starts correctly on g6.2xlarge
- [ ] Verify model is accessible at port 8000
- [ ] Test complete partner workshop flow

### Timeline Context
- **Oct 31, 2025**: Python 3.9 reached upstream end-of-life
- **Apr 26, 2026**: pip 26.1 released (dropped Python 3.9 support)
- **May 4, 2026**: `bootstrap.pypa.io/get-pip.py` updated to enforce Python 3.10+
- **May 8, 2026**: Last working partner deployment (likely cached pip)
- **May 12, 2026**: Partner failures started (cache expired)

### Merge Safety

**Safe to merge because:**
1. ✅ Summit 2026 uses pinned commit - **completely isolated**
2. ✅ Only affects deployments using `version: main`
3. ✅ Partner needs this fix urgently
4. ✅ No backwards compatibility issues
5. ✅ Better approach than the original implementation

**DO NOT merge until:**
- [ ] Testing is complete in partner dev environment
- [ ] Verified on actual AWS g6.2xlarge instance with GPU
- [ ] Stakeholder approval obtained

### References
- [pip 26.1 changelog](https://pip.pypa.io/en/stable/news/)
- [Python 3.9 EOL timeline](https://endoflife.date/python)
- [Partner catalog item](https://github.com/rhpds/partner-agnosticv/tree/main/partner/ai-driven-ansible-automation)
- [Summit catalog item](https://github.com/rhpds/agnosticv/tree/master/summit-2026/lb2759-agentic-aiops-aap-cnv)

### Changed Files
- `roles/rhelai_model_serve/tasks/main.yml` (9 lines removed, 4 lines added)

---
**Target branch**: `feat/continue-dev-config` (will be merged to `main`)  
**Affects**: Partner catalog items using `version: main`  
**Does NOT affect**: Summit 2026 (uses pinned commit `6b591e46...`)  
**Assignee**: @bbethell-1