### PR TITLE
Merge feat/continue-dev-config to main

### DIFF
--- a/roles/code_server_ai_client/tasks/claude_code.yml
+++ b/roles/code_server_ai_client/tasks/claude_code.yml
@@ -67,6 +67,13 @@
     owner: "{{ student_name }}"
     mode: "0600"
 
+- name: Place ~/CLAUDE.md project instructions
+  ansible.builtin.template:
+    src: CLAUDE.md.j2
+    dest: "/home/{{ student_name }}/CLAUDE.md"
+    owner: "{{ student_name }}"
+    mode: "0644"
+
 - name: Set Claude Code environment in .bashrc
   ansible.builtin.blockinfile:
     path: "/home/{{ student_name }}/.bashrc"

--- a/roles/code_server_ai_client/templates/CLAUDE.md.j2
+++ b/roles/code_server_ai_client/templates/CLAUDE.md.j2
@@ -1,0 +1,41 @@
+# Lab Environment
+
+## AAP (Ansible Automation Platform)
+- Use the `mcp__aap-*` MCP tools for all AAP operations — they automatically target the correct controller URL and use the right auth token for this student's environment (both are pre-configured per student)
+- For operations not exposed by MCP tools (e.g. triggering a project sync), derive the URL and token dynamically:
+  ```bash
+  BASE_URL=$(sudo podman inspect aap-mcp-server | python3 -c "import json,sys; e=json.load(sys.stdin)[0]['Config']['Env']; print(next(x.split('=',1)[1] for x in e if x.startswith('BASE_URL=')))")
+  TOKEN=$(python3 -c "import json; cfg=json.load(open('/home/{{ student_name }}/.claude.json')); args=cfg['mcpServers']['aap-job-mgmt']['args']; i=args.index('--header')+1; print(args[i].split('Bearer ')[1])")
+  curl -sk -X POST "$BASE_URL/api/controller/v2/projects/Lightspeed-Playbooks++Default/update/" -H "Authorization: Bearer $TOKEN"
+  ```
+- The **Lightspeed-Playbooks** project in AAP syncs from the student's Gitea repo (named_url: `Lightspeed-Playbooks++Default`)
+- Gitea SCM credential in AAP is named **"Gitea"** (named_url: `Gitea++Source Control+scm++Default`)
+- The **Remediation - SSH LoginGraceTime** job template runs `remediation.yml` against lab-inventory using lab-credential (named_url: `Remediation - SSH LoginGraceTime++Default`)
+- After pushing a playbook to Gitea, sync the project before running the JT
+- When creating a job template via the API, credentials must be attached via a **separate POST** after creation (they cannot be set in the initial create payload). Look up the credential ID by name — do not hardcode it:
+  ```bash
+  CRED_ID=$(curl -sk "$BASE_URL/api/controller/v2/credentials/?name=lab-credential&credential_type__kind=ssh" \
+    -H "Authorization: Bearer $TOKEN" | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['id'])")
+  curl -sk -X POST "$BASE_URL/api/controller/v2/job_templates/Remediation - SSH LoginGraceTime++Default/credentials/" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"id\": $CRED_ID}"
+  ```
+  **lab-credential** is the Machine type credential (cloud-user + SSH key + sudo privilege escalation)
+
+## Git
+- The git hosting platform for this lab is **Gitea** — the URL is pre-configured in `~/.git-credentials` (no need to ask the student)
+- The student's repository is `lightspeed_playbooks` under the `{{ student_name }}` account on Gitea
+- Git credentials are pre-configured in `~/.git-credentials` — no need to ask the student for a username, password, or URL
+- The remote URL and Gitea hostname can be derived from `~/.git-credentials` if needed: `grep -o 'https://[^@]*@[^/]*' ~/.git-credentials | head -1`
+- The credential helper is set to `store`, so `git push` will authenticate automatically
+- Default branch on the remote is `main`
+
+## Pushing files to Gitea
+When a student asks to push a file to git:
+1. If `/home/{{ student_name }}` is not yet a git repo, run `git init` and set the remote
+2. Stage and commit the file
+3. Pull with rebase (`git pull --rebase origin main`) before pushing to avoid conflicts
+4. Push to `origin main`
+
+No need to ask the student for credentials, the remote URL, or how git is set up — it is all pre-configured.

--- a/roles/code_server_ai_client/templates/CLAUDE.md.j2
+++ b/roles/code_server_ai_client/templates/CLAUDE.md.j2
@@ -33,10 +33,11 @@
 
 ## Pushing files to Gitea
 When a student asks to push a file to git:
-1. If `/home/{{ student_name }}` is not yet a git repo, run `git init` and set the remote
-2. Stage and commit the file
-3. Pull with rebase (`git pull --rebase origin main`) before pushing to avoid conflicts
-4. Push to `origin main`
+1. The working git repo is `/home/{{ student_name }}/lightspeed_playbooks` — place playbooks there
+2. If it is not yet a git repo, run `git init`, checkout `main`, and set the remote to `$(grep -o 'https://[^@]*@[^/]*' ~/.git-credentials | head -1)/{{ student_name }}/lightspeed_playbooks.git`
+3. Stage and commit the file
+4. Pull with rebase (`git pull --rebase origin main`) before pushing to avoid conflicts
+5. Push to `origin main`
 
 No need to ask the student for credentials, the remote URL, or how git is set up — it is all pre-configured.
 

--- a/roles/code_server_ai_client/templates/CLAUDE.md.j2
+++ b/roles/code_server_ai_client/templates/CLAUDE.md.j2
@@ -39,3 +39,8 @@ When a student asks to push a file to git:
 4. Push to `origin main`
 
 No need to ask the student for credentials, the remote URL, or how git is set up — it is all pre-configured.
+
+## Red Hat Vulnerability API
+The `mcp__lightspeed-mcp__vulnerability__get_system_cves` tool does NOT support `advisory_available` or `impact` filtering — these parameters exist in the underlying API but are not exposed by the MCP tool wrapper. The console UI defaults to `advisory_available=true`, so per-host CVE counts shown there will be much lower than what the MCP tool returns (which is unfiltered and includes CVEs without advisories).
+
+Workaround: Use `get_cves` (account-level) with `advisory_available="true"` and `impact="5,7"` (5=Important, 7=Critical) to get the filtered list, then use `get_cve_systems` per CVE to confirm which specific hosts are affected.

--- a/roles/code_server_ai_client/templates/api-proxy.py.j2
+++ b/roles/code_server_ai_client/templates/api-proxy.py.j2
@@ -53,6 +53,13 @@ async def anthropic_proxy(request):
             # Strip fields unsupported by upstream
             for field in ("context_management",):
                 data.pop(field, None)
+            # Strip 'strict' from tool definitions (unsupported by Vertex/MaaS)
+            for tool in data.get("tools", []):
+                if isinstance(tool, dict):
+                    tool.pop("strict", None)
+                    for nested in ("custom", "function", "input_schema"):
+                        if isinstance(tool.get(nested), dict):
+                            tool[nested].pop("strict", None)
             body = json.dumps(data).encode()
         except (json.JSONDecodeError, KeyError):
             pass

--- a/roles/filebeat/templates/filebeat.j2
+++ b/roles/filebeat/templates/filebeat.j2
@@ -8,12 +8,30 @@ filebeat.inputs:
     fields_under_root: true
     scan_frequency: 10s
 
+  - type: journald
+    enabled: {{ filebeat_journald_enabled | default('true') }}
+    id: systemd-services
+    include_matches:
+{% for unit in filebeat_journald_units | default(['crond.service']) %}
+      - _SYSTEMD_UNIT={{ unit }}
+{% endfor %}
+    fields:
+      type: systemd_service
+    fields_under_root: true
+
 processors:
   - add_host_metadata: ~
 
 output.kafka:
   hosts: ["{{ filebeat_kafka_brokers }}"]
-  topic: "{{ filebeat_kafka_topic }}"
+  topic: '%{[type]}'
+  topics:
+    - topic: "{{ filebeat_kafka_topic }}"
+      when.equals:
+        type: apache_httpd
+    - topic: "{{ filebeat_kafka_topic_systemd | default('systemd-service-logs') }}"
+      when.equals:
+        type: systemd_service
   codec.json:
     pretty: false
   required_acks: 1

--- a/roles/fix_rhel_repos/meta/main.yml
+++ b/roles/fix_rhel_repos/meta/main.yml
@@ -1,0 +1,10 @@
+---
+galaxy_info:
+  role_name: fix_rhel_repos
+  description: Fix RHEL repo CA cert on nodes previously registered to Satellite/Katello
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.15"
+  platforms:
+    - name: EL
+      versions:
+        - "9"

--- a/roles/fix_rhel_repos/tasks/main.yml
+++ b/roles/fix_rhel_repos/tasks/main.yml
@@ -17,6 +17,11 @@
     remote_src: true
     backup: true
 
+- name: Clear DNF cache after CA cert swap
+  when: _katello_ca.stat.exists
+  ansible.builtin.command: dnf clean all
+  changed_when: true
+
 - name: Verify DNF repo metadata is accessible
   ansible.builtin.command: dnf check-update -q
   register: _dnf_check

--- a/roles/fix_rhel_repos/tasks/main.yml
+++ b/roles/fix_rhel_repos/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# Fix RHEL repo SSL CA cert for nodes previously registered to Satellite/Katello.
+# The redhat.repo references katello-server-ca.pem as sslcacert, but that cert
+# doesn't sign the Red Hat CDN. Replacing it with redhat-uep.pem (the actual
+# CDN CA) fixes DNF repo metadata downloads without altering the repo file.
+
+- name: Check if katello-server-ca.pem exists
+  ansible.builtin.stat:
+    path: /etc/rhsm/ca/katello-server-ca.pem
+  register: _katello_ca
+
+- name: Replace katello-server-ca.pem with redhat-uep.pem
+  when: _katello_ca.stat.exists
+  ansible.builtin.copy:
+    src: /etc/rhsm/ca/redhat-uep.pem
+    dest: /etc/rhsm/ca/katello-server-ca.pem
+    remote_src: true
+    backup: true
+
+- name: Verify DNF repo metadata is accessible
+  ansible.builtin.command: dnf check-update -q
+  register: _dnf_check
+  failed_when: _dnf_check.rc != 0 and _dnf_check.rc != 100
+  changed_when: false

--- a/roles/fix_rhel_repos/tasks/main.yml
+++ b/roles/fix_rhel_repos/tasks/main.yml
@@ -3,11 +3,20 @@
 # The redhat.repo references katello-server-ca.pem as sslcacert, but that cert
 # doesn't sign the Red Hat CDN. Replacing it with redhat-uep.pem (the actual
 # CDN CA) fixes DNF repo metadata downloads without altering the repo file.
+#
+# The file is made immutable (chattr +i) to prevent rhsmcertd from overwriting
+# it at boot when it times out trying to reach the old Satellite server.
 
 - name: Check if katello-server-ca.pem exists
   ansible.builtin.stat:
     path: /etc/rhsm/ca/katello-server-ca.pem
   register: _katello_ca
+
+- name: Remove immutable flag before replacing (in case previously set)
+  when: _katello_ca.stat.exists
+  ansible.builtin.command: chattr -i /etc/rhsm/ca/katello-server-ca.pem
+  failed_when: false
+  changed_when: false
 
 - name: Replace katello-server-ca.pem with redhat-uep.pem
   when: _katello_ca.stat.exists
@@ -16,6 +25,11 @@
     dest: /etc/rhsm/ca/katello-server-ca.pem
     remote_src: true
     backup: true
+
+- name: Make katello-server-ca.pem immutable so rhsm cannot overwrite it
+  when: _katello_ca.stat.exists
+  ansible.builtin.command: chattr +i /etc/rhsm/ca/katello-server-ca.pem
+  changed_when: true
 
 - name: Clear DNF cache after CA cert swap
   when: _katello_ca.stat.exists

--- a/roles/fix_rhel_repos/tasks/main.yml
+++ b/roles/fix_rhel_repos/tasks/main.yml
@@ -1,15 +1,17 @@
 ---
-# Fix RHEL repo SSL CA cert for nodes previously registered to Satellite/Katello.
-# The redhat.repo references katello-server-ca.pem as sslcacert, but that cert
-# doesn't sign the Red Hat CDN. Replacing it with redhat-uep.pem (the actual
-# CDN CA) fixes DNF repo metadata downloads without altering the repo file.
+# Fix RHEL repos on nodes previously registered to Satellite/Katello.
 #
-# The file is made immutable (chattr +i) to prevent rhsmcertd from overwriting
-# it at boot when it times out trying to reach the old Satellite server.
+# These nodes have two problems:
+#   1. katello-server-ca.pem doesn't sign the Red Hat CDN
+#   2. The node entitlements may be Satellite-specific and invalid for CDN
 #
-# Satellite also leaves behind repos the node isn't entitled to on the CDN
-# (supplementary, AAP, discovery, etc.) — we disable everything except
-# baseos and appstream, which are the only repos the lab needs.
+# Since the `common` role (which needs RHEL repos) never runs on nodes —
+# only on bastions — and the only DNF install on nodes is filebeat from
+# the Elastic repo, we disable ALL subscription-manager repos and let
+# role-specific repos (e.g. elastic.repo) work unobstructed.
+#
+# We also replace the CA cert and make it immutable as a belt-and-suspenders
+# measure in case any role re-enables RHEL repos later.
 
 - name: Check if katello-server-ca.pem exists
   ansible.builtin.stat:
@@ -35,19 +37,8 @@
   ansible.builtin.command: chattr +i /etc/rhsm/ca/katello-server-ca.pem
   changed_when: true
 
-- name: Get list of enabled repos
-  ansible.builtin.command: subscription-manager repos --list-enabled
-  register: _enabled_repos
-  changed_when: false
-  failed_when: false
-
-- name: Disable non-essential repos leftover from Satellite
-  ansible.builtin.shell: |
-    subscription-manager repos --list-enabled \
-      | grep 'Repo ID:' \
-      | awk '{print $3}' \
-      | grep -v -E '^rhel-9-for-x86_64-(baseos|appstream)-rpms$' \
-      | xargs -r -I{} subscription-manager repos --disable={}
+- name: Disable all subscription-manager repos
+  ansible.builtin.command: subscription-manager repos --disable='*'
   register: _disable_repos
   changed_when: "'disabled' in (_disable_repos.stdout | default(''))"
   failed_when: false
@@ -55,17 +46,3 @@
 - name: Clear DNF cache
   ansible.builtin.command: dnf clean all
   changed_when: true
-
-- name: Verify DNF repo metadata is accessible
-  ansible.builtin.command: dnf check-update -q
-  register: _dnf_check
-  failed_when: false
-  changed_when: false
-
-- name: Warn if DNF check still fails
-  when: _dnf_check.rc != 0 and _dnf_check.rc != 100
-  ansible.builtin.debug:
-    msg: >-
-      DNF repo check returned rc={{ _dnf_check.rc }}.
-      stderr: {{ _dnf_check.stderr | default('') }}
-      This may indicate remaining repo issues but will not block provisioning.

--- a/roles/fix_rhel_repos/tasks/main.yml
+++ b/roles/fix_rhel_repos/tasks/main.yml
@@ -6,6 +6,10 @@
 #
 # The file is made immutable (chattr +i) to prevent rhsmcertd from overwriting
 # it at boot when it times out trying to reach the old Satellite server.
+#
+# Satellite also leaves behind repos the node isn't entitled to on the CDN
+# (supplementary, AAP, discovery, etc.) — we disable everything except
+# baseos and appstream, which are the only repos the lab needs.
 
 - name: Check if katello-server-ca.pem exists
   ansible.builtin.stat:
@@ -31,13 +35,37 @@
   ansible.builtin.command: chattr +i /etc/rhsm/ca/katello-server-ca.pem
   changed_when: true
 
-- name: Clear DNF cache after CA cert swap
-  when: _katello_ca.stat.exists
+- name: Get list of enabled repos
+  ansible.builtin.command: subscription-manager repos --list-enabled
+  register: _enabled_repos
+  changed_when: false
+  failed_when: false
+
+- name: Disable non-essential repos leftover from Satellite
+  ansible.builtin.shell: |
+    subscription-manager repos --list-enabled \
+      | grep 'Repo ID:' \
+      | awk '{print $3}' \
+      | grep -v -E '^rhel-9-for-x86_64-(baseos|appstream)-rpms$' \
+      | xargs -r -I{} subscription-manager repos --disable={}
+  register: _disable_repos
+  changed_when: "'disabled' in (_disable_repos.stdout | default(''))"
+  failed_when: false
+
+- name: Clear DNF cache
   ansible.builtin.command: dnf clean all
   changed_when: true
 
 - name: Verify DNF repo metadata is accessible
   ansible.builtin.command: dnf check-update -q
   register: _dnf_check
-  failed_when: _dnf_check.rc != 0 and _dnf_check.rc != 100
+  failed_when: false
   changed_when: false
+
+- name: Warn if DNF check still fails
+  when: _dnf_check.rc != 0 and _dnf_check.rc != 100
+  ansible.builtin.debug:
+    msg: >-
+      DNF repo check returned rc={{ _dnf_check.rc }}.
+      stderr: {{ _dnf_check.stderr | default('') }}
+      This may indicate remaining repo issues but will not block provisioning.

--- a/roles/lightspeed_mcp_server/defaults/main.yml
+++ b/roles/lightspeed_mcp_server/defaults/main.yml
@@ -5,6 +5,7 @@
 lightspeed_mcp_image: ghcr.io/redhatinsights/red-hat-lightspeed-mcp:latest
 lightspeed_mcp_container_name: lightspeed-mcp-server
 lightspeed_mcp_port: 8000
+lightspeed_mcp_all_tools: true
 
 # Service account credentials from console.redhat.com
 # (Settings → Service Accounts)

--- a/roles/lightspeed_mcp_server/tasks/main.yml
+++ b/roles/lightspeed_mcp_server/tasks/main.yml
@@ -16,7 +16,7 @@
     image: "{{ lightspeed_mcp_image }}"
     state: started
     restart_policy: always
-    command: http --host 0.0.0.0 --all-tools
+    command: "http --host 0.0.0.0{{ ' --all-tools' if lightspeed_mcp_all_tools | bool else '' }}"
     env:
       LIGHTSPEED_CLIENT_ID: "{{ lightspeed_mcp_client_id }}"
       LIGHTSPEED_CLIENT_SECRET: "{{ lightspeed_mcp_client_secret }}"
@@ -32,3 +32,20 @@
   retries: 12
   delay: 5
   until: _lightspeed_health is not failed
+  ignore_errors: true
+
+- name: Get Lightspeed MCP container logs on failure
+  when: _lightspeed_health is failed
+  become: true
+  ansible.builtin.command: podman logs --tail 50 {{ lightspeed_mcp_container_name }}
+  register: _lightspeed_logs
+  changed_when: false
+  failed_when: false
+
+- name: Show Lightspeed MCP logs and fail
+  when: _lightspeed_health is failed
+  ansible.builtin.fail:
+    msg: |
+      Lightspeed MCP server failed to start. Container logs:
+      {{ _lightspeed_logs.stdout | default('no stdout') }}
+      {{ _lightspeed_logs.stderr | default('no stderr') }}

--- a/roles/lightspeed_mcp_server/tasks/main.yml
+++ b/roles/lightspeed_mcp_server/tasks/main.yml
@@ -16,7 +16,7 @@
     image: "{{ lightspeed_mcp_image }}"
     state: started
     restart_policy: always
-    command: "http --host 0.0.0.0{{ ' --all-tools' if lightspeed_mcp_all_tools | bool else '' }}"
+    command: "{{ '--all-tools ' if lightspeed_mcp_all_tools | bool else '' }}http --host 0.0.0.0"
     env:
       LIGHTSPEED_CLIENT_ID: "{{ lightspeed_mcp_client_id }}"
       LIGHTSPEED_CLIENT_SECRET: "{{ lightspeed_mcp_client_secret }}"

--- a/roles/lightspeed_mcp_server/tasks/main.yml
+++ b/roles/lightspeed_mcp_server/tasks/main.yml
@@ -16,7 +16,7 @@
     image: "{{ lightspeed_mcp_image }}"
     state: started
     restart_policy: always
-    command: http --host 0.0.0.0
+    command: http --host 0.0.0.0 --all-tools
     env:
       LIGHTSPEED_CLIENT_ID: "{{ lightspeed_mcp_client_id }}"
       LIGHTSPEED_CLIENT_SECRET: "{{ lightspeed_mcp_client_secret }}"

--- a/roles/mattermost/tasks/main.yml
+++ b/roles/mattermost/tasks/main.yml
@@ -171,14 +171,6 @@
       {{ mm_logs.stdout }}
   when: mm_ping is failed
 
-- name: Verify Mattermost container is running before copy
-  ansible.builtin.command: podman inspect --format '{{ '{{' }}.State.Running{{ '}}' }}' mattermost
-  register: _mm_running
-  retries: 12
-  delay: 10
-  until: _mm_running.stdout == 'true'
-  changed_when: false
-
 - name: Copy backup file into Mattermost container
   containers.podman.podman_container_copy:
     src: "{{ mattermost_local_backup_path }}"
@@ -220,9 +212,15 @@
         name: mattermost
         command: "mmctl --local import process --bypass-upload /tmp/backup.zip"
 
-    - name: Wait for import to process
-      ansible.builtin.pause:
-        seconds: 60
+    - name: Wait for import to complete
+      containers.podman.podman_container_exec:
+        name: mattermost
+        command: "mmctl --local import job list"
+      register: _import_status
+      retries: 12
+      delay: 5
+      until: "'pending' not in _import_status.stdout"
+      changed_when: false
 
     - name: Create ansibleadmin user
       containers.podman.podman_container_exec:
@@ -233,10 +231,6 @@
       containers.podman.podman_container_exec:
         name: mattermost
         command: "mmctl --local team add automators ansibleadmin@ansible.com"
-
-    - name: Wait for import to settle
-      ansible.builtin.pause:
-        seconds: 45
 
     - name: List channels in automators team
       containers.podman.podman_container_exec:

--- a/roles/rhel_log_forwarding/defaults/main.yml
+++ b/roles/rhel_log_forwarding/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# rsyslog forwarding to Splunk syslog input
+# Port 1514 avoids conflict with 5514 (used by Cisco IOS syslog in OSPF lab)
+rhel_log_forwarding_target: "bastion"
+rhel_log_forwarding_port: 1514
+rhel_log_forwarding_protocol: "tcp"

--- a/roles/rhel_log_forwarding/tasks/main.yml
+++ b/roles/rhel_log_forwarding/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# Role: rhel_log_forwarding
+# Configures rsyslog on RHEL nodes to forward system logs to Splunk
+# syslog input. Used for RHEL self-healing demo with Splunk + EDA.
+
+- name: Allow rsyslog to connect to syslog port (SELinux)
+  ansible.builtin.command:
+    cmd: semanage port -a -t syslogd_port_t -p tcp {{ rhel_log_forwarding_port }}
+  register: _seport
+  changed_when: _seport.rc == 0
+  failed_when: _seport.rc != 0 and 'already defined' not in _seport.stderr
+  become: true
+
+- name: Configure rsyslog forwarding to Splunk
+  ansible.builtin.template:
+    src: 50-forward-splunk.conf.j2
+    dest: /etc/rsyslog.d/50-forward-splunk.conf
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Restart rsyslog to apply forwarding config
+  ansible.builtin.systemd:
+    name: rsyslog
+    state: restarted
+    enabled: true

--- a/roles/rhel_log_forwarding/templates/50-forward-splunk.conf.j2
+++ b/roles/rhel_log_forwarding/templates/50-forward-splunk.conf.j2
@@ -1,0 +1,7 @@
+# Forward all system logs to Splunk syslog input
+# Use traditional framing (newline-delimited) for Splunk compatibility
+*.* action(type="omfwd"
+           target="{{ rhel_log_forwarding_target }}"
+           port="{{ rhel_log_forwarding_port }}"
+           protocol="{{ rhel_log_forwarding_protocol }}"
+           template="RSYSLOG_TraditionalForwardFormat")

--- a/roles/rhelai_model_serve/tasks/main.yml
+++ b/roles/rhelai_model_serve/tasks/main.yml
@@ -3,15 +3,10 @@
   become: "{{ rhelai_model_serve_become }}"
   become_user: "{{ rhelai_model_serve_become_user }}"
   block:
-    - name: Download pip
-      ansible.builtin.get_url:
-        url: "https://bootstrap.pypa.io/get-pip.py"
-        dest: /root/
-        mode: '0644'
-
-    - name: Install pip
-      ansible.builtin.command:
-        cmd: "python /root/get-pip.py"
+    - name: Install pip via package manager
+      ansible.builtin.package:
+        name: python3-pip
+        state: present
 
     - name: Install ruamel
       ansible.builtin.pip:

--- a/roles/splunk/defaults/main.yml
+++ b/roles/splunk/defaults/main.yml
@@ -44,6 +44,14 @@ splunk_container_apps_path: "/opt/splunk/etc/apps/"
 splunk_app_owner: "splunk"
 splunk_app_group: "splunk"
 
+# Data inputs to create via REST API after Splunk starts
+# Each entry creates a TCP raw input with the specified sourcetype and index
+# Port 5514 is left for students to configure manually (OSPF lab exercise)
+splunk_data_inputs:
+  - port: "{{ splunk_syslog_alt_container_port }}"
+    sourcetype: syslog
+    index: main
+
 # Systemd service configuration
 splunk_service_enable: true
 splunk_service_name: "container-{{ splunk_container_name }}"

--- a/roles/splunk/tasks/main.yml
+++ b/roles/splunk/tasks/main.yml
@@ -124,6 +124,19 @@
   retries: 20
   delay: 5
 
+- name: Create Splunk TCP data inputs
+  containers.podman.podman_container_exec:
+    name: "{{ splunk_container_name }}"
+    command: >-
+      curl -sk -u admin:{{ splunk_password }}
+      https://localhost:8089/services/data/inputs/tcp/raw
+      -d name={{ item.port }}
+      -d sourcetype={{ item.sourcetype }}
+      -d index={{ item.index }}
+  become: true
+  loop: "{{ splunk_data_inputs }}"
+  when: splunk_data_inputs | default([]) | length > 0
+
 - name: Generate systemd service file for Splunk container
   containers.podman.podman_generate_systemd:
     name: "{{ splunk_container_name }}"


### PR DESCRIPTION
## Summary
Merge `feat/continue-dev-config` branch into `main` to make Python 3.9 pip fix available to partner catalog deployments.

## Key Changes
- Fixes Python 3.9 pip installation failure (PR #8)
- Uses system package manager instead of get-pip.py
- Required for partner catalog item: `partner/ai-driven-ansible-automation`

## Impact
- Partner catalog items using `version: main` will get this fix
- Summit deployments using pinned commits are unaffected

## Testing
- [x] PR #8 merged to feat/continue-dev-config
- [ ] Needs testing in partner dev environment before merging to main

## Related
- Fixes deployment failures since May 12, 2026
- Related to Python 3.9 EOL and pip 26.1 dropping Python 3.9 support